### PR TITLE
feat: allow setting config path via env variable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-clap = { version = "3.1", features = ["derive"] }
+clap = { version = "3.1", features = ["derive", "env"] }
 ckb-async-runtime = "0.105"
 ckb-crypto = "0.105"
 ckb-hash = "0.105"

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ pub const PLUGINS_DIRNAME: &str = "plugins";
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
-    #[clap(short, long)]
+    #[clap(short, long, env = "OTXP_CONFIG_PATH")]
     config_path: String,
 }
 


### PR DESCRIPTION
Allow the app read config path from the environment variable
`OTXP_CONFIG_PATH`.

- Enable clap feature env to read option from environment variable.
- Set the environment variable name to `OTXP_CONFIG_PATH` for the option
  `--config-path`, where the prefix is the acronym of Open TX (Transaction) Pool.
