### PR TITLE
fix: bug in atomic swap plugin

### DIFF
--- a/integration-test/dev_chain/dev/specs/dev.toml
+++ b/integration-test/dev_chain/dev/specs/dev.toml
@@ -145,13 +145,7 @@ genesis_epoch_length = 10
 permanent_difficulty_in_dummy = true
 
 [params.hardfork]
-rfc_0028 = 0
-rfc_0029 = 0
-rfc_0030 = 0
-rfc_0031 = 0
-rfc_0032 = 0
-rfc_0036 = 0
-rfc_0038 = 0
+ckb2023 = 0
 
 [pow]
 func = "Dummy"


### PR DESCRIPTION
Fixed a bug in atomic swap plugin. A brief description is given below. 

For a new OTX, it is not indexed in the following cases: there are swap candidates in the swap plugin, but none of the candidate swap proposals end up being matched.
